### PR TITLE
Refactor the immediately returned variables

### DIFF
--- a/fastapi_auth/auth_app.py
+++ b/fastapi_auth/auth_app.py
@@ -107,8 +107,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
     @classmethod
     def read(cls, db: Session, user_id: UserID) -> Optional[UserInDBT]:
         db_user = db.query(cls.orm_type).filter(cls.orm_type.user_id == user_id).first()
-        user = cls.in_db_type(**db_user.dict()) if db_user is not None else None
-        return user
+        return cls.in_db_type(**db_user.dict()) if db_user is not None else None
 
     def authenticate(self, db: Session, username: str, password: RawPassword) -> UserInDBT:
         user: Optional[UserOrmT] = db.query(self.orm_type).filter(self.orm_type.username == username).first()
@@ -177,8 +176,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
                 db=db, username=form_data.username, password=RawPassword(form_data.password)
             )
             tokens = self.login_flow(db=db, user=user, scopes=form_data.scopes)
-            response = tokens.to_response()
-            return response
+            return tokens.to_response()
 
         @auth_router.post(
             refresh_url,
@@ -191,8 +189,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
             Consume a refresh token to request a new access token
             """
             tokens = self.refresh_token_flow(db=db, token=token)
-            response = tokens.to_response()
-            return response
+            return tokens.to_response()
 
         @auth_router.get(token_url + "/validate", response_model=APIMessage, dependencies=[Depends(self.get_user)])
         def validate_token() -> APIMessage:
@@ -274,8 +271,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
             """
             Retrieve users.
             """
-            result = db.query(self.orm_type).offset(skip).limit(limit).all()
-            return result
+            return db.query(self.orm_type).offset(skip).limit(limit).all()
 
         @admin_router.post("/users", response_model=api_type)
         def create_user(
@@ -303,8 +299,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
 
     @staticmethod
     def login_flow(db: Session, user: UserInDBT, scopes: List[str]) -> "TokenPair":
-        token_pair = _create_tokens(db=db, user=user, scopes=scopes)
-        return token_pair
+        return _create_tokens(db=db, user=user, scopes=scopes)
 
     def refresh_token_flow(self, db: Session, token: "Token") -> "TokenPair":
         """
@@ -316,8 +311,7 @@ class BaseAuthRouterBuilder(Generic[UserCreateT, UserCreateRequestT, UserInDBT, 
         if user is None:
             raise_auth_error(detail="User not found; try logging in again")
         _consume_refresh_token(db=db, token=token)
-        token_pair = _create_tokens(db=db, user=user, scopes=token.payload.scopes)
-        return token_pair
+        return _create_tokens(db=db, user=user, scopes=token.payload.scopes)
 
     def setup_first_superuser(self, engine: sa.engine.Engine, **extra_create_kwargs: Any) -> None:
         settings = self.settings

--- a/fastapi_auth/fastapi_util/orm/base.py
+++ b/fastapi_auth/fastapi_util/orm/base.py
@@ -32,8 +32,7 @@ class CustomBase:
             return camel2snake(cls.__name__)
 
     def dict(self) -> Dict[str, Any]:
-        data = {key: getattr(self, key) for key in self.__table__.c.keys()}
-        return data
+        return {key: getattr(self, key) for key in self.__table__.c.keys()}
 
 
 _Base = declarative_base(cls=CustomBase, metaclass=CustomMeta)

--- a/fastapi_auth/fastapi_util/orm/guid_type.py
+++ b/fastapi_auth/fastapi_util/orm/guid_type.py
@@ -43,9 +43,6 @@ class GUID(TypeDecorator):  # type: ignore
 
     @no_type_check
     def process_result_value(self, value, dialect):
-        if value is None:
-            return value
-        else:
-            if not isinstance(value, uuid.UUID):
-                value = uuid.UUID(value)
-            return value
+        if value is not None and not isinstance(value, uuid.UUID):
+            value = uuid.UUID(value)
+        return value

--- a/fastapi_auth/fastapi_util/util/timing.py
+++ b/fastapi_auth/fastapi_util/util/timing.py
@@ -76,12 +76,11 @@ class MetricNamer:
                 route = r
                 break
         if hasattr(route, "endpoint") and hasattr(route, "name"):
-            name = f"{self.prefix}{route.endpoint.__module__}.{route.name}"  # type: ignore
+            return f"{self.prefix}{route.endpoint.__module__}.{route.name}"
         elif isinstance(route, Mount):
-            name = f"{type(route.app).__name__}<{route.name!r}>"
+            return f"{type(route.app).__name__}<{route.name!r}>"
         else:
-            name = str(f"<Path: {scope['path']}>")
-        return name
+            return str(f"<Path: {scope['path']}>")
 
 
 def get_cpu_time() -> float:

--- a/tests/test_auth_app/test_endpoints/test_debug.py
+++ b/tests/test_auth_app/test_endpoints/test_debug.py
@@ -91,15 +91,24 @@ class TestDebug(TestAuthApiBase):
     def test_login_password_fails(self) -> None:
         admin_username = get_auth_settings().first_superuser
         assert admin_username is not None
-        bad_password = "wrong"
-        message = self._get_login_response(admin_username, bad_password, APIMessage, HTTP_401_UNAUTHORIZED)
-        assert message.detail == "Incorrect password"
+        self._extracted_from_test_login_username_fails_4(
+            admin_username, "Incorrect password"
+        )
 
     def test_login_username_fails(self) -> None:
         bad_username = "bad@test.com"
-        bad_password = "wrong"
-        message = self._get_login_response(bad_username, bad_password, APIMessage, HTTP_401_UNAUTHORIZED)
-        assert message.detail == "User not found"
+        self._extracted_from_test_login_username_fails_4(
+            bad_username, "User not found"
+        )
+
+
+    def _extracted_from_test_login_username_fails_4(self, arg0, arg1):
+        bad_password = 'wrong'
+        message = self._get_login_response(
+            arg0, bad_password, APIMessage, HTTP_401_UNAUTHORIZED
+        )
+
+        assert message.detail == arg1
 
     def test_read_users(self, admin_access_headers: Dict[str, str]) -> None:
         url = self.debug_auth_app.url_path_for(AdminAuthEndpointName.read_users)


### PR DESCRIPTION
Returning the result directly shortens the code and removes an unnecessary variable, reducing the mental load of reading the function.
Where intermediate variables can be useful is if they then get used as a parameter or a condition, and the name can act as a comment on what the variable represents. In the case where you're returning it from a function, the function name is there to tell you what the result is